### PR TITLE
annotating controllers with @Alternative

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ target
 .settings
 bin/
 Rakefile
+.idea/
+*.iml

--- a/README-pt-br.markdown
+++ b/README-pt-br.markdown
@@ -20,6 +20,21 @@ Para configurar, coloque em seu hibernate.cfg.xml a entidade:
 
 	br.com.caelum.vraptor.dash.statement.Statement
 	br.com.caelum.vraptor.dash.uristats.Stat
+
+Habilite os controllers do vraptor-dash no beans.xml:
+
+```
+<beans ...>
+    <alternatives>
+        <class>br.com.caelum.vraptor.dash.config.ConfigController</class>
+        <class>br.com.caelum.vraptor.dash.hibernate.AuditController</class>
+        <class>br.com.caelum.vraptor.dash.hibernate.stats.RequestsController</class>
+        <class>br.com.caelum.vraptor.dash.monitor.RoutesController</class>
+        <class>br.com.caelum.vraptor.dash.monitor.SystemController</class>
+    </alternatives>
+</beans>
+```
+
 	
 Crie também um componente que implemente a interface StatementAwareUser:
 

--- a/README.markdown
+++ b/README.markdown
@@ -22,6 +22,20 @@ Add the entity to your hibernate.cfg.xml:
 	br.com.caelum.vraptor.dash.statement.Statement
 	br.com.caelum.vraptor.dash.uristats.Stat
 
+Enable vraptor-dash controllers in your beans.xml:
+
+```
+<beans ...>
+    <alternatives>
+        <class>br.com.caelum.vraptor.dash.config.ConfigController</class>
+        <class>br.com.caelum.vraptor.dash.hibernate.AuditController</class>
+        <class>br.com.caelum.vraptor.dash.hibernate.stats.RequestsController</class>
+        <class>br.com.caelum.vraptor.dash.monitor.RoutesController</class>
+        <class>br.com.caelum.vraptor.dash.monitor.SystemController</class>
+    </alternatives>
+</beans>
+```
+
 Create a component that implements StatementAwareUser:
 
 	@Component

--- a/src/main/java/br/com/caelum/vraptor/dash/config/ConfigController.java
+++ b/src/main/java/br/com/caelum/vraptor/dash/config/ConfigController.java
@@ -4,6 +4,7 @@ package br.com.caelum.vraptor.dash.config;
 import java.io.IOException;
 import java.util.List;
 
+import javax.enterprise.inject.Alternative;
 import javax.inject.Inject;
 import javax.servlet.http.HttpServletResponse;
 
@@ -20,6 +21,7 @@ import br.com.caelum.vraptor.freemarker.FreemarkerView;
 import br.com.caelum.vraptor.view.HttpResult;
 import freemarker.template.TemplateException;
 
+@Alternative
 @Controller
 public class ConfigController {
 

--- a/src/main/java/br/com/caelum/vraptor/dash/hibernate/AuditController.java
+++ b/src/main/java/br/com/caelum/vraptor/dash/hibernate/AuditController.java
@@ -7,6 +7,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import javax.enterprise.inject.Alternative;
 import javax.inject.Inject;
 
 import net.sf.ehcache.CacheManager;
@@ -32,6 +33,7 @@ import br.com.caelum.vraptor.view.HttpResult;
 
 import com.mchange.v2.c3p0.mbean.C3P0PooledDataSource;
 
+@Alternative
 @Controller
 public class AuditController {
 

--- a/src/main/java/br/com/caelum/vraptor/dash/hibernate/stats/RequestsController.java
+++ b/src/main/java/br/com/caelum/vraptor/dash/hibernate/stats/RequestsController.java
@@ -1,5 +1,6 @@
 package br.com.caelum.vraptor.dash.hibernate.stats;
 
+import javax.enterprise.inject.Alternative;
 import javax.inject.Inject;
 
 import br.com.caelum.vraptor.Controller;
@@ -7,6 +8,7 @@ import br.com.caelum.vraptor.Path;
 import br.com.caelum.vraptor.Result;
 import br.com.caelum.vraptor.view.HttpResult;
 
+@Alternative
 @Controller
 public class RequestsController {
 

--- a/src/main/java/br/com/caelum/vraptor/dash/monitor/RoutesController.java
+++ b/src/main/java/br/com/caelum/vraptor/dash/monitor/RoutesController.java
@@ -6,6 +6,7 @@ import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
 
+import javax.enterprise.inject.Alternative;
 import javax.inject.Inject;
 
 import br.com.caelum.vraptor.Controller;
@@ -18,6 +19,7 @@ import br.com.caelum.vraptor.http.route.Router;
 import br.com.caelum.vraptor.view.HttpResult;
 import freemarker.template.TemplateException;
 
+@Alternative
 @Controller
 public class RoutesController {
 

--- a/src/main/java/br/com/caelum/vraptor/dash/monitor/SystemController.java
+++ b/src/main/java/br/com/caelum/vraptor/dash/monitor/SystemController.java
@@ -8,6 +8,7 @@ import java.nio.charset.Charset;
 import java.util.Map.Entry;
 import java.util.Set;
 
+import javax.enterprise.inject.Alternative;
 import javax.inject.Inject;
 
 import org.slf4j.Logger;
@@ -25,6 +26,7 @@ import br.com.caelum.vraptor.view.HttpResult;
 import br.com.caelum.vraptor.view.Results;
 import freemarker.template.TemplateException;
 
+@Alternative
 @Controller
 public class SystemController {
 

--- a/src/main/java/br/com/caelum/vraptor/dash/statement/StatementController.java
+++ b/src/main/java/br/com/caelum/vraptor/dash/statement/StatementController.java
@@ -2,6 +2,7 @@ package br.com.caelum.vraptor.dash.statement;
 
 import java.util.List;
 
+import javax.enterprise.inject.Alternative;
 import javax.inject.Inject;
 
 import br.com.caelum.vraptor.Controller;
@@ -17,6 +18,7 @@ import br.com.caelum.vraptor.validator.Validator;
 import br.com.caelum.vraptor.view.HttpResult;
 import br.com.caelum.vraptor.view.Results;
 
+@Alternative
 @Controller
 public class StatementController {
 


### PR DESCRIPTION
I've annotated every controller with `@Alternative` and the user of the plugin should enable what controller he needs to use in the beans.xml.

If we don't annotate it with `@Alternative`, the user needs to provide implementations for all the interfaces used by these controllers (`MonitorAwareUser`, `HibernateStatsAwareUser`, ...). Currently, if the plugin user don't implement those interfaces, the application will throw the following exceptions:
https://gist.github.com/csokol/28cdd94ec8190570b5ef
